### PR TITLE
Adds control to reverse the order of color palletes 

### DIFF
--- a/client/src/components/MultiColorPhoto.js
+++ b/client/src/components/MultiColorPhoto.js
@@ -25,6 +25,7 @@ const MultiColorPhoto = () => {
     "#FFA500",
   ]);
   const [remapColors, setRemapColors] = useState(true);
+  const [reversePalette, setReversePalette] = useState(false);
   const [showPreview, setShowPreview] = useState(true);
   const stlPreviewRef = useRef(null);
 
@@ -93,6 +94,7 @@ const MultiColorPhoto = () => {
       selectedColors.map((color) => color.slice(1)).join(",")
     );
     formData.append("remap_colors", remapColors);
+    formData.append("reverse_palette", reversePalette);
 
     try {
       const response = await axios.post(
@@ -211,6 +213,17 @@ const MultiColorPhoto = () => {
                     className="form-checkbox h-5 w-5 text-blue-600"
                   />
                   <span className="ml-2 text-gray-700">Remap Colors</span>
+                </label>
+              </div>
+              <div className="mb-4">
+                <label className="flex items-center">
+                  <input
+                    type="checkbox"
+                    checked={reversePalette}
+                    onChange={(e) => setReversePalette(e.target.checked)}
+                    className="form-checkbox h-5 w-5 text-blue-600"
+                  />
+                  <span className="ml-2 text-gray-700">Reverse Palette Order</span>
                 </label>
               </div>
               <button

--- a/server/color.py
+++ b/server/color.py
@@ -23,7 +23,7 @@ def sort_palette_by_brightness(palette):
     return sorted_palette
 
 
-def quantize_colors(image, selected_colors, remap_colors_to_palette=True):
+def quantize_colors(image, selected_colors, remap_colors_to_palette=True, reverse_palette=False):
     # Convert image to numpy array
     np_image = np.array(image)
 
@@ -44,6 +44,10 @@ def quantize_colors(image, selected_colors, remap_colors_to_palette=True):
     # Sort selected colors by brightness
     selected_colors = np.array(selected_colors)
     sorted_selected_colors = sort_palette_by_brightness(selected_colors)
+
+    if reverse_palette:
+        sorted_quantized_colors = sorted_quantized_colors[::-1]
+        sorted_selected_colors = sorted_selected_colors[::-1]
 
     if remap_colors_to_palette:
         # Create a mapping from quantized colors to selected colors

--- a/server/main.py
+++ b/server/main.py
@@ -67,13 +67,14 @@ def quantize_image_colors():
     ]
 
     remap_colors = request.form.get("remap_colors", "true").lower() == "true"
+    reverse_palette = request.form.get("reverse_palette", "false").lower() == "true"
 
     # Read the image
     img = Image.open(file.stream)
 
     # Quantize colors
     quantized_img, color_palette = quantize_colors(
-        img, selected_colors, remap_colors_to_palette=remap_colors
+        img, selected_colors, remap_colors_to_palette=remap_colors, reverse_palette=reverse_palette
     )
 
     # Convert the quantized image to base64


### PR DESCRIPTION
Allows user to print the darkest colors "higher" (closer to the foreground) and the lighter colors further away.

Preview of UI
<img width="1560" alt="image" src="https://github.com/user-attachments/assets/2d7900c3-b9d6-40ab-a708-d1df092c0796">

Without reversing
![image](https://github.com/user-attachments/assets/cf87c58a-b8da-4f48-ab98-69d1fba474e5)

With reversing
![image](https://github.com/user-attachments/assets/d6882272-4b15-41f8-9f03-ef73cf0cb852)

